### PR TITLE
feat(get movies): add get endpoint to retrieve movies with filters

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,3 +7,26 @@ exports.create = async (payload) => {
 
   return new Movie({ id: movie.id }).fetch();
 };
+
+exports.getAllMovies = (params) => {
+  return new Movie().query((movie) => {
+    params = params || {};
+
+    if (params.release_year) {
+      movie.where('release_year', params.release_year);
+    }
+    if (params.after) {
+      movie.where('release_year', '>=', params.after);
+    }
+    if (params.before) {
+      movie.where('release_year', '<=', params.before);
+    }
+    if (params.title) {
+      if (params.fuzzy_title) {
+        movie.where('title', 'ilike', `%${params.title}%`);
+      } else {
+        movie.where('title', params.title);
+      }
+    }
+  }).fetchAll();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,22 +1,37 @@
 'use strict';
 
-const Controller     = require('./controller');
-const MovieValidator = require('../../../validators/movie');
+const Controller          = require('./controller');
+const MovieValidator      = require('../../../validators/movie');
+const MovieListValidator  = require('../../../validators/movielist');
 
 exports.register = (server, options, next) => {
 
-  server.route([{
-    method: 'POST',
-    path: '/movies',
-    config: {
-      handler: (request, reply) => {
-        reply(Controller.create(request.payload));
-      },
-      validate: {
-        payload: MovieValidator
+  server.route([
+    {
+      method: 'POST',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.create(request.payload));
+        },
+        validate: {
+          payload: MovieValidator
+        }
+      }
+    },
+    {
+      method: 'GET',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.getAllMovies(request.query));
+        },
+        validate: {
+          query: MovieListValidator
+        }
       }
     }
-  }]);
+  ]);
 
   next();
 

--- a/lib/validators/movielist.js
+++ b/lib/validators/movielist.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieListValidator = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  fuzzy_title: Joi.boolean().optional(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional(),
+  after: Joi.number().integer().min(1878).max(9999).optional(),
+  before: Joi.number().integer().min(1878).max(9999).optional()
+}).and('title', 'fuzzy_title')
+  .without('release_year', ['after', 'before'])
+  .without('after', 'release_year')
+  .without('before', 'release_year');
+
+module.exports = MovieListValidator;

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,17 +1,107 @@
 'use strict';
 
+const Knex = require('../../../../lib/libraries/knex.js');
+
 const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie = require('../../../../lib/models/movie.js');
 
 describe('movie controller', () => {
 
-  describe('create', () => {
+  beforeEach('clear tables before test start', async () => {
 
-    it('creates a movie', async () => {
+    await Knex.raw('TRUNCATE movies CASCADE');
+
+  });
+
+  describe('post', () => {
+
+    it('posts a movie and gets back a serialized movie object', async () => {
       const payload = { title: 'WALL-E' };
-
       const movie = await Controller.create(payload);
-
       expect(movie.get('title')).to.eql(payload.title);
+
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('retrieves all the movies', async () => {
+      const movieModelList = await new Movie().fetchAll();
+      const controllerList = await Controller.getAllMovies();
+      expect(movieModelList.length).to.eql(controllerList.length);
+    });
+
+    it('retrieves movies by release year and fuzzy match', async () => {
+      const payload = { title: 'The Dark Knight', release_year: 2008 };
+      const movie = await Controller.create(payload);
+      expect(movie.get('title')).to.eql(payload.title);
+
+      const queryParams = {
+        title: 'The',
+        fuzzy_title: true,
+        release_year: 2008
+      };
+
+      const controllerList = await Controller.getAllMovies(queryParams);
+      expect(controllerList.length).to.eql(1);
+      expect(controllerList.models[0].get('title')).to.eql(payload.title);
+
+    });
+
+    it('retrieves movies by release year and exact match', async () => {
+      const payload = { title: 'The Dark Knight', release_year: 2008 };
+      const movie = await Controller.create(payload);
+      expect(movie.get('title')).to.eql(payload.title);
+
+      const queryParams = {
+        title: 'The Dark Knight',
+        fuzzy_title: false,
+        release_year: 2008
+      };
+
+      const controllerList = await Controller.getAllMovies(queryParams);
+
+      expect(controllerList.length).to.eql(1);
+      expect(controllerList.models[0].get('title')).to.eql(payload.title);
+
+    });
+
+    it('gets movies by release year and exact match', async () => {
+      const payload = { title: 'The Dark Knight', release_year: 2008 };
+      const movie = await Controller.create(payload);
+      expect(movie.get('title')).to.eql(payload.title);
+
+      const queryParams = {
+        title: 'The Dark Knight',
+        fuzzy_title: false,
+        release_year: 2008
+      };
+
+      const controllerList = await Controller.getAllMovies(queryParams);
+
+      expect(controllerList.length).to.eql(1);
+      expect(controllerList.models[0].get('title')).to.eql(payload.title);
+
+    });
+
+    it('gets movies by passing a range', async () => {
+      const payload = { title: 'The Dark Knight', release_year: 2008 };
+      const movie = await Controller.create(payload);
+      expect(movie.get('title')).to.eql(payload.title);
+
+      const queryParams = {
+        title: 'The Dark Knight',
+        fuzzy_title: false,
+        after: 2000,
+        before: 2010
+      };
+
+      const controllerList = await Controller.getAllMovies(queryParams);
+
+      expect(controllerList.length).to.eql(1);
+      expect(controllerList.models[0].get('title')).to.eql(payload.title);
+      expect(controllerList.models[0].get('release_year')).to.eql(payload.release_year);
 
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,20 +1,47 @@
 'use strict';
 
+const Knex = require('../../../../lib/libraries/knex.js');
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+
 const Movies = require('../../../../lib/server');
 
 describe('movies integration', () => {
 
-  describe('create', () => {
+  beforeEach('clear tables before test start', async () => {
 
-    it('creates a movie', async () => {
+    await Knex.raw('TRUNCATE movies CASCADE');
+
+  });
+
+  describe('post', () => {
+
+    it('posts a movie', async () => {
       const response = await Movies.inject({
         url: '/movies',
         method: 'POST',
-        payload: { title: 'Volver' }
+        payload: { title: 'Inception' }
       });
 
       expect(response.statusCode).to.eql(200);
       expect(response.result.object).to.eql('movie');
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('returns a list of movies', async () => {
+      const params = { title: 'Inception', release_year: 2010 };
+      await Controller.create(params);
+      const response = await Movies.inject({
+        url: '/movies?title=ion&fuzzy_title=true&release_year=2010',
+        method: 'GET'
+      });
+
+      expect(response.statusCode).to.eql(200);
+      expect(response.result[0].object).to.eql('movie');
+      expect(response.result[0].title).to.eql(params.title);
     });
 
   });

--- a/test/validators/movielist.test.js
+++ b/test/validators/movielist.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieListValidator = require('../../lib/validators/movielist');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+  });
+
+  describe('fuzzy_title', () => {
+
+    it('is boolean', () => {
+      const payload = { title: 'a'.repeat(250), fuzzy_title: 'foo' };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('fuzzy_title');
+      expect(result.error.details[0].type).to.eql('boolean.base');
+    });
+
+    it('appears with title', () => {
+      const payload = { title: 'a'.repeat(250) };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error.details[0].type).to.eql('object.and');
+    });
+
+  });
+
+  describe('after', () => {
+
+    it('should not appear with release_year', () => {
+      const payload = {
+        title: 'a'.repeat(250),
+        fuzzy_title: true,
+        release_year: 2000,
+        after: 2001
+      };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('object.without');
+    });
+
+  });
+
+  describe('before', () => {
+
+    it('should not appear with release_year', () => {
+      const payload = {
+        title: 'a'.repeat(250),
+        fuzzy_title: true,
+        release_year: 2000,
+        before: 2001
+      };
+      const result = Joi.validate(payload, MovieListValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('object.without');
+    });
+
+  });
+
+});


### PR DESCRIPTION
**What:** 

Stands up an endpoint to retrieve a list of movies based on a few filters.

**Why:** 

This is a core component of the sfmovies onboarding project - https://lobsters.atlassian.net/browse/DE-262

**Details:**

This PR sets up the `/GET` movies endpoint to retrieve a list of movies from the DB. The endpoint accepts 5 parameters - 

- `title`: movie title as a string (required and always accompanied by `fuzzy_title`),
- `fuzzy_title`: a boolean indicating whether or not we need to perform a fuzzy match,
- `release_year`: an integer indicating the year the said movie is released,
- `after`: an integer specifying the start year,
- `before`: an integer specifying the end year,

`after` and `before` indicate the range of years.

**Notes:**

To test this change, pull down the branch and run `yarn test`. Additionally, you can create a movie with the post endpoint from https://github.com/sachinmurali/sfmovies/pull/5 and try to retrieve the newly created movie.

If I were to create a movie called `Inception`, you can stand up the server via `yarn start` and run a `url --location --request GET 'http://localhost:3000/movies?fuzzy_title=True&title=ion'`. You can provide different combination of filters (mentioned above) to acheive the desired result. 